### PR TITLE
Remove public keyword from interface

### DIFF
--- a/src/common/common.js
+++ b/src/common/common.js
@@ -55,7 +55,7 @@ function cleanCommentData(comment, skipAdditional = []) {
   const toSkip = [...skipDefaults, ...skipAdditional];
 
   comment = comment.replace(/<span[^>]*>(.*?)<\/span>/, "$1")
-    .replace(/\{\@link([^}]*)\}/g, "$1")
+    .replace(/\{\@link ([^}]*)\}/g, "$1")
     .replace(/<br>|&bull;/g, "")
     .replace(/&ndash;/g, "–")
     .replace(/&mdash;/g, "—");

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -170,7 +170,7 @@ function fixType(type) {
  */
 function getPropertyParts(content) {
   let [, name = "", assignmentType, value = ""] = 
-    /^\s*([\w\d.]+)\s*([=:])\s*([\s\S]*)/.exec(content) || [];
+    /^\s*([\w\d.$]+)\s*([=:])\s*([\s\S]*)/.exec(content) || [];
 
   if (assignmentType === "=" && !/\./.test(name)) name = '';
   name = name.replace(/.*\./, "");

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -187,7 +187,7 @@ function getPropertyParts(content) {
  * - any otherwise
  *
  * @param {string} content 
- * @return {'object' | 'number' | 'string' | 'function', 'any' }
+ * @return {'object' | 'number' | 'string' | 'function' | 'any' }
  */;
 function getValueType(content) {
   const startsWith = content[0];

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ module.exports = {
       data
         .replace(/CIQ\.ChartEngine\.AdvancedInjectable/gm, 'CIQ.ChartEngine')
         .replace(/@memberof!/gim, '@memberof')
+        .replace(/@tsinterface/, '@typedef') // Process @tsinterface the same as @typedef but avoids inclusion in generated JS documentation
       );
   },
   postprocessing: function(data, source) {

--- a/src/config.js
+++ b/src/config.js
@@ -6,7 +6,7 @@ module.exports = {
       data
         .replace(/CIQ\.ChartEngine\.AdvancedInjectable/gm, 'CIQ.ChartEngine')
         .replace(/@memberof!/gim, '@memberof')
-        .replace(/@tsinterface/, '@typedef') // Process @tsinterface the same as @typedef but avoids inclusion in generated JS documentation
+        .replace(/@tsinterface/g, '@typedef') // Process @tsinterface the same as @typedef but avoids inclusion in generated JS documentation
       );
   },
   postprocessing: function(data, source) {

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -56,7 +56,11 @@ function intoClasses(classes, members) {
         path: interfacePath,
         name: interfaceName,
         TSDef: [`interface ${interfaceName}`],
+        isInterface: true,
       }
+
+      // remove public keyword from interface member definition
+      member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
 
       pairs[path] = { path, class: interfaceObj, members: [member] };
 
@@ -68,6 +72,9 @@ function intoClasses(classes, members) {
         info(member, 'class member', `name ${member.name} @memberof parameter has not defined object path of "${path}"`);
       }
       continue;
+    }
+    if (pairs[path].class.isInterface) {
+      member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
     }
     membersLookup[member.path.concat(member.name).join('.')] = member; 
 

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -49,22 +49,27 @@ function intoClasses(classes, members) {
 
     if (pairs[path] === undefined) {
 
+      
       const interfaceName = member.path.pop()
       const interfacePath = member.path;
-      const interfaceObj = {
-        comment: '',
-        path: interfacePath,
-        name: interfaceName,
-        TSDef: [`interface ${interfaceName}`],
-        isInterface: true,
+
+      const isClassLike = interfaceName[0] === interfaceName[0].toLocaleUpperCase();
+      if (isClassLike) {
+        const interfaceObj = {
+          comment: '',
+          path: interfacePath,
+          name: interfaceName,
+          TSDef: [`interface ${interfaceName}`],
+          isInterface: true,
+        }
+  
+        // remove public keyword from interface member definition
+        member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
+  
+        pairs[path] = { path, class: interfaceObj, members: [member] };
+  
+        continue;
       }
-
-      // remove public keyword from interface member definition
-      member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
-
-      pairs[path] = { path, class: interfaceObj, members: [member] };
-
-      continue;
 
       if (!membersLookup[path]) { 
         // Inform only if there is no member either with this path
@@ -73,6 +78,7 @@ function intoClasses(classes, members) {
       }
       continue;
     }
+    
     if (pairs[path].class.isInterface) {
       member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
     }

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -67,6 +67,8 @@ function intoClasses(classes, members) {
         member.TSDef[0] = member.TSDef[0].replace(/^public static |^public /, '');
   
         pairs[path] = { path, class: interfaceObj, members: [member] };
+
+        membersLookup[member.path.concat(interfaceName, member.name).join('.')] = member;
   
         continue;
       }

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -64,7 +64,7 @@ function intoClasses(classes, members) {
         }
   
         // remove public keyword from interface member definition
-        member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
+        member.TSDef[0] = member.TSDef[0].replace(/^public static |^public /, '');
   
         pairs[path] = { path, class: interfaceObj, members: [member] };
   
@@ -78,9 +78,9 @@ function intoClasses(classes, members) {
       }
       continue;
     }
-    
+
     if (pairs[path].class.isInterface) {
-      member.TSDef[0] = member.TSDef[0].replace(/^public /, '');
+      member.TSDef[0] = member.TSDef[0].replace(/^public static |^public /, '');
     }
     membersLookup[member.path.concat(member.name).join('.')] = member; 
 

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -194,7 +194,7 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     const returns = getReturns(comment);
 
     if(!name.length && !types.length) {
-      name = propertyFunctionName || namedFunction.exec(firstLine)[0];
+      name = namedFunction.exec(firstLine)[0];
     }
 
     tail = `(${outputParams(params)})`;

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -5,6 +5,7 @@ const {
   getParamParts,
   combineDestructuredArguments,
   tabLines,
+  getPropertyParts,
 } = require('../common/common');
 
 /* Definition */
@@ -128,42 +129,25 @@ function createConstructorsTSDefs(classes, { expandPropertyDeclarationBasedOnDef
  */
 function setMemberDefinitions(definition, comment, modifiers, constructor = false, expand) {
   const firstLine = definition.substring(0, definition.indexOf('\n')) || definition;
-  let name = '';
-  let value = '';
   let isPropertyType = false;
   const isDeprecated = /\* @deprecated/m.test(comment);
-  const [, propertyFunctionName] = /\s*(\w*):\s*function/
-    .exec(firstLine) || [];
+
+  let { name, valueType, value } = getPropertyParts(definition);
 
   if (constructor === true) {
     name = 'constructor';
     value = definition.substring(definition.indexOf('=') + 1);
-  } else
-  // If in an object? Probably Object.defineProperty or object.definePropertie
-  if (
-    !propertyFunctionName && 
-    firstLine.indexOf(':') > -1 && 
-    (firstLine.indexOf('{') === -1 || firstLine.indexOf('{') > firstLine.indexOf(':'))
-  ) {
-    if (expand) {
-      isPropertyType = true;
-      ({ name, value } = getTSPropertyDef(definition));
-    } else {
-      name = firstLine.substring(0, firstLine.indexOf(':')).trim();
-      value = definition.substring(definition.indexOf(':') + 1);
-    }
-  } else
-  // If setting value equal to function
-  if (firstLine.indexOf('=') > -1) {
-    name = firstLine.substring(
-      firstLine.lastIndexOf('.', firstLine.indexOf('=')) + 1,
-      firstLine.indexOf('='),
-    ).trim();
-    value = definition.substring(definition.indexOf('=') + 1);
   }
+  // If in an object? Probably Object.defineProperty or object.definePropertie
+  if ( valueType === "object" && expand) {
+    isPropertyType = true;
+    if (expand) {
+      ({ name, value } = getTSPropertyDef(definition));
+    }
+  } 
 
   let tail = ''
-  if(constructor || (!isPropertyType && isFunction.test(firstLine))) {
+  if(constructor || valueType === "function" || isFunction.test(firstLine)) {
     let all = getArguments(firstLine);
     all = combineDestructuredArguments(all);
     const args = all.split(',')
@@ -223,7 +207,7 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     const type = getFieldType(comment);
     if (type !== '') {
       tail = `: ${
-        isPropertyType && value && value !== '{}'
+        valueType === 'object' && value && value !== '{}'
           ? type.replace(/object/, value)
           : type
       }`;
@@ -247,19 +231,6 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
   }
 }
 
-/**
- * @param {string} firstLine
- */
-function getFunc(firstLine) {
-  if (firstLine.includes('function(')) {
-    return firstLine.substring(firstLine.indexOf('function(') + 9, firstLine.indexOf(')'));
-  }
-  if (firstLine.includes('function (')) {
-    return firstLine.substring(firstLine.indexOf('function (') + 10, firstLine.indexOf(')'))
-  }
-
-  return false
-}
 
 function getArguments(expression) {
   return expression.substring(expression.indexOf('(')+1, expression.indexOf(')'));
@@ -409,9 +380,11 @@ const { getObjectDef } = require('../common/common');
  * }
  */
 function getTSPropertyDef(str) {
-  const [name, ...objStr] = str.split(/:\s*/);
-  const objDefStr = objStr.join(': ');
-  if (!objDefStr) return;
+  let { name, valueType, value: objDefStr } = getPropertyParts(str);
+
+  if (valueType !== "object") {
+    return { name, value: valueType }
+  }
 
   // Check if property object has properties identified with comments
   const types = getCommentAreas(objDefStr, '* @memberof ');

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -430,7 +430,7 @@ function toTSDeclaration(obj) {
   return JSON
     .stringify(getObj(obj), null, 2)
     .replace(/\"/g, '')
-    .replace(/~~~/g, '"');
+    .replace(/~~~/g, '"'); // replace placeholders
 
   function getObj(obj) {
     if (obj === null) return 'any';
@@ -439,8 +439,8 @@ function toTSDeclaration(obj) {
       .reduce((acc, [key, value]) => {
         let type = (typeof value).replace('function', 'Function');
         if (type === 'object') type = getObj(value);
-        if (/ /.test(key)) {
-          key = "~~~" + key + "~~~";
+        if (/ |\//.test(key)) {
+          key = "~~~" + key + "~~~"; // placeholder for the "
         }
         return { ...acc, [key]: type };
       }, {});

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -144,7 +144,7 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     if (expand) {
       ({ name, value } = getTSPropertyDef(definition));
     }
-  } 
+  }
 
   let tail = ''
   if(constructor || valueType === "function" || isFunction.test(firstLine)) {
@@ -427,7 +427,10 @@ function toObject(str) {
  */
 function toTSDeclaration(obj) {
   if (obj === undefined) return;
-  return JSON.stringify(getObj(obj), null, 2).replace(/\"/g, '');
+  return JSON
+    .stringify(getObj(obj), null, 2)
+    .replace(/\"/g, '')
+    .replace(/~~~/g, '"');
 
   function getObj(obj) {
     if (obj === null) return 'any';
@@ -436,6 +439,9 @@ function toTSDeclaration(obj) {
       .reduce((acc, [key, value]) => {
         let type = (typeof value).replace('function', 'Function');
         if (type === 'object') type = getObj(value);
+        if (/ /.test(key)) {
+          key = "~~~" + key + "~~~";
+        }
         return { ...acc, [key]: type };
       }, {});
   }

--- a/test/merge-analysis/into-classes.js
+++ b/test/merge-analysis/into-classes.js
@@ -69,7 +69,7 @@ describe('into-classes.js', () => {
     const result = intoClasses(classes, members);
 
     it('get correct class params', () => {
-      expect(result.length).eql(2);
+      expect(result.length).eql(3); // 2 for classes one interface for 'Some.AnotherClass
       expect(result[0].path).eql(['Some']);
       expect(result[1].path).eql(['Some']);
     });


### PR DESCRIPTION
Removes public keyword from interface members.
Corrects test now when interface is created when class is not available.