### PR TITLE
27547 better logging

### DIFF
--- a/src/code-analysis/comment-collector.js
+++ b/src/code-analysis/comment-collector.js
@@ -179,15 +179,13 @@ function collectExceptions(members) {
       !comment.includes('* @property ') &&
       !comment.includes('* @module')
     ) {
+      // We haven't gotten around to fixing these yet, so skip
       if(comment.includes('* @namespace')) {
         if (
-          !comment.includes('* @namespace WebComponents') &&
-          !comment.includes('The following is a list of ADVANCED injectable methods.')
-        ) {
-          console.error(_member);
-        } else {
+          comment.includes('* @namespace WebComponents') ||
+          comment.includes('The following is a list of ADVANCED injectable methods.')
+        )
           continue;
-        }
       }
 
       result.push(_member);

--- a/src/code-analysis/comment-collector.js
+++ b/src/code-analysis/comment-collector.js
@@ -158,14 +158,13 @@ function applyMemberRoles(members) {
 }
 
 /**
- * @param {Area[]} members
+ * @param {Area[]} docs
  */
-function collectExceptions(members) {
+function collectExceptions(docs) {
   const result = [];
 
-  for (const member of members) {
-    const _member = { ...member };
-    const { comment } = member;
+  for (const doc of docs) {
+    const { comment } = doc;
 
     if (comment.includes('* @private')) continue;
 
@@ -188,7 +187,7 @@ function collectExceptions(members) {
           continue;
       }
 
-      result.push(_member);
+      result.push(doc);
     }
 
   }

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -1,6 +1,9 @@
+const { error } = require('./logger');
+
 /* Definition */
 module.exports = {
   tabLines,
+  checkMutuallyExclusiveTags,
   cleanCommentData,
   fixType,
   getDefinition,
@@ -31,6 +34,59 @@ function tabLines(str, tab = '  ') {
   }
 
   return result.join('\n');
+}
+
+/**
+ * Simple Regex to detect a JSDoc comment.
+ * Does not detect wheter the tag is real JSDoc tag just looks for a string in the shape of a tag. 
+ * @type Regex
+ */
+const jsdoc = new RegExp(/@\w+\b/);
+
+/**
+ * Simple Regex to detect the text of the JSDoc comment.
+ * 
+ * Starts from tag and goes until the end of the line.
+ * **NOTE** Does not try to figure out if the comment continues onto the next line so a comment _could_ be incomplete
+ */
+const jsdocText = new RegExp(/@\w+\b.*/g);
+
+function checkMutuallyExclusiveTags(area, classLike) {
+
+  if (area.area) area = area.area;
+  const { comment } = area
+
+  let jsDocs = comment.split('\n')
+    .map( line => jsdoc.exec(line) && jsdoc.exec(line)[0])
+    .filter( c => !!c )
+
+  const nonClass = [
+		'@callback',
+    '@default',
+    '@inner',
+    '@member',
+    '@memberof',
+    '@memberOf',
+    '@static',
+    '@type',
+    '@typedef'
+  ];
+
+  const classish = [
+    '@class',
+    '@constructor',
+    '@namespace'
+  ];
+
+  if(!classLike) {
+    let isClassy = jsDocs.find( line => classish.includes(line));
+    if (isClassy)
+     error(area, area.value, `Comment contains mutually exclusive JSDoc tags. Documented as ${area.type} but contains ${isClassy} tag`)
+  } else {
+    let nonClassy = jsDocs.find( line => nonClass.includes(line));
+    if (nonClassy) error(area, area.value, `Class ${area.value} contains mutually exclusive JSDoc ${nonClassy} tag`)
+  }
+
 }
 
 /**

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -64,6 +64,7 @@ function checkMutuallyExclusiveTags(area, classLike) {
 		'@callback',
     '@default',
     '@inner',
+    '@instance',
     '@member',
     '@memberof',
     '@memberOf',

--- a/src/common/exceptionHandler.js
+++ b/src/common/exceptionHandler.js
@@ -1,0 +1,29 @@
+
+/**
+ * Holds parsed references that do not contain complete or valid paths when attempting to create modules, namespaces, classes, etc...
+ * @type Map
+ */
+class Exceptions { 
+    constructor() {
+        this.exceptions = new Map;
+    }
+    
+    check(definitions) {
+        const { exceptions } = this
+        for (const type of exceptions) {
+            console.log(type)
+        }
+    }
+    
+    push(type, entry) {
+        const { exceptions } = this
+        if(!exceptions.has(type)) exceptions.set(type, [])
+        const key = exceptions.get(type)
+        key.push(entry)
+    }
+}
+const ExceptionHandler = new Exceptions()
+
+module.exports = { 
+    ExceptionHandler,
+}

--- a/src/common/logger.js
+++ b/src/common/logger.js
@@ -26,6 +26,7 @@ module.exports = {
  * @type {LogOut[]}
  */
 const collection = [];
+module.exports.collection = collection;
 
 /* Public */
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -166,7 +166,10 @@ function generate(dataFrom, config = defaultConfig) {
 
   if(postprocessing) definitions = postprocessing(definitions, dataFrom);
 
-	if(collection.filter( issue => issue.type === 'error').length) throw new Error('YOU HAVE FAILED THIS CITY')
+	if(collection.filter( issue => issue.type === 'error').length) 
+    throw new Error('Found errors while building definition file:\n' + 
+    JSON.stringify(collection.filter( issue => issue.type === 'error'), null, '  ')
+    );
 
   return definitions
 }

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ function generate(dataFrom, config = defaultConfig) {
   const module = createModuleTSDefs(notedObjects.module, importTagName, exportTagName);
 
   // Include declarations into each other and get a strings
-  const classDefs = intoClasses(classes, [...constructors, ...members]);
+  const classDefs = intoClasses(classes, [...constructors, ...members], { includePrivate });
   const typeDefs = intoTypedefs(types);
   const callbacksDefs = intoCallbacks(callbacks);
   const namespaceDefs = intoNamespaces(namespaces, [

--- a/src/index.js
+++ b/src/index.js
@@ -166,10 +166,7 @@ function generate(dataFrom, config = defaultConfig) {
 
   if(postprocessing) definitions = postprocessing(definitions, dataFrom);
 
-	if(collection.filter( issue => issue.type === 'error').length) 
-    throw new Error('Found errors while building definition file:\n' + 
-    JSON.stringify(collection.filter( issue => issue.type === 'error'), null, '  ')
-    );
+  if(collection.filter( issue => issue.type === 'error').length) process.exitCode = 1;
 
   return definitions
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const { exit } = require('process');
 const { basename } = require('path');
 const { existsSync, readFileSync, writeFileSync } = require('fs');
 
-const { conclusion } = require('./common/logger');
+const { conclusion, collection } = require('./common/logger');
 const { collectAllNotedObjects } = require('./code-analysis/comment-collector');
 const { createModuleTSDefs } = require('./noted-objects-analysis/module-parser');
 const { createMembersTSDefs, createConstructorsTSDefs } = require('./noted-objects-analysis/members-parser');
@@ -165,6 +165,9 @@ function generate(dataFrom, config = defaultConfig) {
   let definitions = moduleDefs.map(def => def.code).join('\n').replace(/\n(\s+)\n/g, '\n');
 
   if(postprocessing) definitions = postprocessing(definitions, dataFrom);
+
+	if(collection.filter( issue => issue.type === 'error').length) throw new Error('YOU HAVE FAILED THIS CITY')
+
   return definitions
 }
 
@@ -173,8 +176,8 @@ function generate(dataFrom, config = defaultConfig) {
  */
 
 /**
- * 
- * @param {Definition[]} members 
+ *
+ * @param {Definition[]} members
  * @return {Definition[]}
  */
 function classStaticMembersToNamespaceFunctions(members) {
@@ -190,9 +193,9 @@ function classStaticMembersToNamespaceFunctions(members) {
           /^public static /,
           type === 'field'
             ? isReadOnly ? 'const ' : 'let '
-            : 'function ' 
+            : 'function '
         );
-      
+
       return {
         area,
         path,

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,15 @@ function generate(dataFrom, config = defaultConfig) {
 
   // Grab all required comments into grouped objects
   const notedObjects = collectAllNotedObjects(dataFrom);
+  
+  // Check for unclassified jsdocs
+  if(notedObjects.unclassified.length) {
+	notedObjects.unclassified.forEach((obj) => {
+	  console.error("Found unclassified jsdoc: " + obj.definition);
+	});
+	process.exitCode = 1;
+  }
+
 
   // Convert the data into something that could be used as a definition
   const members = createMembersTSDefs(notedObjects.members, {

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -1,6 +1,6 @@
 const { values } = require('lodash');
 const { tabLines } = require('../common/common');
-const { info } = require('../common/logger');
+const { info, error } = require('../common/logger');
 
 /* Definition */
 module.exports = {
@@ -19,7 +19,8 @@ module.exports = {
  * @param {Definition[]} classes
  * @param {Definition[]} members
  */
-function intoClasses(classes, members) {
+function intoClasses(classes, members, options = {}) {
+  const { includePrivate } = options;
   /**
    * @type {Code[]}
    */
@@ -91,8 +92,15 @@ function intoClasses(classes, members) {
 
   // Generate the class code
   for (const pair of values(pairs)) {
+    // This can happen when your documented members are all marked as private OR something is not documented.
     if (pair.members.length === 0) {
-      info(pair.class, 'Class', `path ${pair.path} has no defined members`);
+      info(pair.class, 'Class', `path ${pair.path} has no defined members, nothing will be documented.`);
+    }
+
+    // Do not add private classes
+    if (pair.class.comment.includes("@private")) {
+      error(pair.class, pair.class.TSDef, `${pair.path} contains a @private tag`)
+      if (includePrivate) continue;
     }
 
     const code =

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -77,7 +77,7 @@ function intoClasses(classes, members, options = {}) {
       if (!membersLookup[path]) { 
         // Inform only if there is no member either with this path
         // Object properties containing JSDocs are processed separately
-        info(member, 'class member', `name ${member.name} @memberof parameter has not defined object path of "${path}"`);
+        error(member, 'class member', `name ${member.name} @memberof parameter has not defined object path of "${path}"`);
       }
       continue;
     }

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -1,5 +1,5 @@
 const { values } = require('lodash');
-const { tabLines } = require('../common/common');
+const { checkMutuallyExclusiveTags, tabLines } = require('../common/common');
 const { info, error } = require('../common/logger');
 
 /* Definition */
@@ -92,6 +92,11 @@ function intoClasses(classes, members, options = {}) {
 
   // Generate the class code
   for (const pair of values(pairs)) {
+
+    // Interfaces do not have an 'area', they are not checked
+    if(pair.class.area) checkMutuallyExclusiveTags(pair.class.area, true);
+    
+
     // This can happen when your documented members are all marked as private OR something is not documented.
     if (pair.members.length === 0) {
       info(pair.class, 'Class', `path ${pair.path} has no defined members, nothing will be documented.`);

--- a/src/merge-analysis/into-classes.js
+++ b/src/merge-analysis/into-classes.js
@@ -77,7 +77,7 @@ function intoClasses(classes, members, options = {}) {
       if (!membersLookup[path]) { 
         // Inform only if there is no member either with this path
         // Object properties containing JSDocs are processed separately
-        error(member, 'class member', `name ${member.name} @memberof parameter has not defined object path of "${path}"`);
+        error(member, 'class member', `name ${member.name} @memberof parameter has undefined object path of "${path}"`);
       }
       continue;
     }

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -1,6 +1,7 @@
 const { groupBy, set, get } = require('lodash');
 const {
   fixType,
+  checkMutuallyExclusiveTags,
   cleanCommentData,
   getParamParts,
   combineDestructuredArguments,
@@ -54,7 +55,10 @@ function createMembersTSDefs(
   const result = [];
   for (const member of members) {
     const comment = member.comment;
+
+    checkMutuallyExclusiveTags(member, false);
     if (/\* @private/.test(comment) && !includePrivate) continue;
+
     const { TSDef, name } = setMemberDefinitions(
       member.definition,
       comment,

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -44,8 +44,8 @@ const namedFunction = new RegExp(/\w*(?=\s*\()/);
  */
 function createMembersTSDefs(
   members, 
-  { 
-    includePrivate, 
+  {
+    includePrivate,
     expandPropertyDeclarationBasedOnDefault
   } = {}) {
   /**

--- a/src/noted-objects-analysis/types-parser.js
+++ b/src/noted-objects-analysis/types-parser.js
@@ -1,5 +1,5 @@
 const { values, groupBy, set } = require('lodash');
-const { fixType, cleanCommentData } = require('../common/common');
+const { fixType, cleanCommentData, checkMutuallyExclusiveTags } = require('../common/common');
 
 /* Definitions */
 module.exports = {
@@ -25,6 +25,9 @@ function createTypedefsTSDefs(areas) {
 
   for (const area of areas) {
     if (area.type === 'typedef') {
+
+      checkMutuallyExclusiveTags(area, false);
+
       const comment = area.comment;
       const { path, name } = setTypeDefinition(area);
       const fields = getProperties(area.comment);
@@ -55,6 +58,9 @@ function createCallbacksTSDefs(areas) {
 
   for (const area of areas) {
     if (area.type === 'callback') {
+
+      checkMutuallyExclusiveTags(area, false);
+
       const comment = area.comment;
       const { path, name } = setFunctionDefinition(area);
       const fields = getParams(area.comment);


### PR DESCRIPTION
## Slightly better logging. Plays nicely with ChartIQ Packager

Short of rewriting the way everything is parsed this may be the best we can do for throwing errors since we parse based on specific JSDoc tags (can't parse all comments for "wrong" tags).

## Changes
- Logs issues as errors so they show up when being watched from a gulpfile.
- Throws an error when classes with a `@private` tag are documented when not supposed to be allowing private tags.