### PR TITLE
Adds Dependabot workflow to file Kanbanize ticket on Dependabot PR's

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,56 @@
+name: Dependabot
+
+# This "on" event must be pull_request_target in order to have access to GH secrets.
+# See the following: 
+# https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  pull_request_target:
+    branches: [ labeled ]
+
+jobs:
+  create-security-bug-ticket:
+    name: Kanbanize Security Bug tracker
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'security')
+    steps:
+      - shell: bash
+        with: asd
+        run: |
+          curl --location --request POST 'https://cosaic.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json' \
+          --header 'apikey: ${{secrets.KANBANIZE_APIKEY}}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "boardid": "15",
+              "title": "[Bug]: Security Vulnerability",
+              "description": ${{ github.event.pullrequest.body }},
+              "color": "F37325",
+              "size": "medium",
+              "tags": "[BUG]",
+              "column": "Ready to Start",
+              "lane": "Ongoing Release"
+          }'
+
+  create-dependency-ticket:
+    name: Kanbanize Dependency tracker
+    runs-on: ubuntu-latest
+    if: contains(github.envent.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - shell: bash
+        with:
+        run: |
+          curl --location --request POST 'https://cosaic.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json' \
+          --header 'apikey: ${{secrets.KANBANIZE_APIKEY}}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "boardid": "15",
+              "title": "[Enhancement]: Update Dependencies",
+              "description": ${{ github.event.pullrequest.body }},
+              "color": "77569B",
+              "size": "medium",
+              "tags": "[Enhancement]",
+              "column": "Ready to Start",
+              "lane": "Ongoing Release"
+          }'
+
+      

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dts-gen",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -910,9 +910,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {


### PR DESCRIPTION
## Creates a workflow file for Dependabot to be run when PR's are filed.

The workflow file checks the contents label of the PR that has been applied to determine whether it is a security or dependency update and files a matching Kanbanize ticket.

Because this workflow uses an API key to authenticate the dispatch to Kanbanize, it needs access to secrets meaning it must use a pull_request_target event to be dispatched correctly with the right permissions.

