### PR TITLE
Fix TS 1040 error: async should not be used in ambient contexts

### DIFF
--- a/src/code-analysis/comment-collector.js
+++ b/src/code-analysis/comment-collector.js
@@ -140,7 +140,6 @@ function applyMemberRoles(members) {
     ) {
       _member.modifiers.push('static');
     }
-    if (/async/.test(member.definition)) _member.modifiers.push('async')
 
     if (!member.comment.includes(' @type ') && /\(.*\)/.test(member.definition)) {
       _member.type = 'method';

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -10,6 +10,8 @@ const {
   isFunction
 } = require('../common/common');
 
+const { info } = require('../common/logger');
+
 /* Definition */
 module.exports = {
   createMembersTSDefs,
@@ -191,6 +193,11 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     
     if(!name.length && !types.length) {
       name = namedFunction.exec(firstLine);
+    }
+
+    if (definition.includes("async") && returns!= "Promise") {
+      let n = Array.isArray(name) ? name[0] : name
+      info([n, returns], 'Invalid Return', 'Async functions should always return a Promise!')
     }
 
     tail = `(${outputParams(params)})`;

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -195,7 +195,7 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
       name = namedFunction.exec(firstLine);
     }
 
-    if (definition.includes("async") && returns!= "Promise") {
+    if (definition.includes("async") && !returns.includes("Promise")) {
       const id = `${memberof}#${Array.isArray(name) ? name[0] : name}`
       console.log(`${id}: Async functions should always return a Promise. Instead returned ${returns}`) // @TODO remove this after cleaning up definitions and use debug level
       info(id, 'Invalid Return', `Async functions should always return a Promise. Instead returned ${returns}`)

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -196,8 +196,9 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     }
 
     if (definition.includes("async") && returns!= "Promise") {
-      let n = Array.isArray(name) ? name[0] : name
-      info([n, returns], 'Invalid Return', 'Async functions should always return a Promise!')
+      const id = `${memberof}#${Array.isArray(name) ? name[0] : name}`
+      console.log(`${id}: Async functions should always return a Promise. Instead returned ${returns}`) // @TODO remove this after cleaning up definitions and use debug level
+      info(id, 'Invalid Return', `Async functions should always return a Promise. Instead returned ${returns}`)
     }
 
     tail = `(${outputParams(params)})`;

--- a/test/code-analysis/comment-collector.js
+++ b/test/code-analysis/comment-collector.js
@@ -220,7 +220,7 @@ static aFunction(arg1, arg2) {};
 /**
  * @memberof Foo.Bar
  * @param {string} arg1
- * @param {number} arg2
+ * @param {number} arg2asdfasfd
  */
 async aFunction(arg1, arg2) {};
 `;
@@ -232,7 +232,7 @@ async aFunction(arg1, arg2) {};
       expect(result.members.length).eql(1);
       expect(result.members[0].value).eql('Foo.Bar');
       expect(result.members[0].type).eql('method');
-      expect(result.members[0].modifiers).eql(['public', 'async']);
+      expect(result.members[0].modifiers).eql(['public']);
       expect(result.members[0].definition).eql('async aFunction(arg1, arg2)');
     });
 

--- a/test/code-analysis/comment-collector.js
+++ b/test/code-analysis/comment-collector.js
@@ -220,7 +220,7 @@ static aFunction(arg1, arg2) {};
 /**
  * @memberof Foo.Bar
  * @param {string} arg1
- * @param {number} arg2asdfasfd
+ * @param {number} arg2
  */
 async aFunction(arg1, arg2) {};
 `;

--- a/test/noted-objects-analysis/members-parser.js
+++ b/test/noted-objects-analysis/members-parser.js
@@ -194,7 +194,7 @@ describe('members-parser.js', () => {
       // Make sure we start from a clean state
       flush();
       const result = createMembersTSDefs(source);
-      console.log(collection[0])
+
       expect(collection[0].object).eql(['baz', 'void'])
       expect(collection[0].name).eql('Invalid Return')
       expect(collection[0].message).eql('Async functions should always return a Promise!')

--- a/test/noted-objects-analysis/members-parser.js
+++ b/test/noted-objects-analysis/members-parser.js
@@ -155,11 +155,11 @@ describe('members-parser.js', () => {
 * Variadic function
 * @param {string} first First string to concatenate
 * @param {...string} others others to concatenate
-* @return {string}
+* @return {Promise}
 * @memberof Foo.Bar`,
           value:  'Foo.Bar',
           definition: 'async baz(first, ...others){',
-          modifiers: ['public', 'async'],
+          modifiers: ['public'],
           type: 'method'
         }
       ]
@@ -167,7 +167,7 @@ describe('members-parser.js', () => {
       const result = createMembersTSDefs(source);
 
       expect(result[0].TSDef).eql([
-        "public async baz(first: string, ...others: string[]): string"
+        "public baz(first: string, ...others: string[]): Promise"
       ])
     });
 

--- a/test/noted-objects-analysis/members-parser.js
+++ b/test/noted-objects-analysis/members-parser.js
@@ -195,9 +195,9 @@ describe('members-parser.js', () => {
       flush();
       const result = createMembersTSDefs(source);
 
-      expect(collection[0].object).eql(['baz', 'void'])
+      expect(collection[0].object).eql('Foo.Bar#baz')
       expect(collection[0].name).eql('Invalid Return')
-      expect(collection[0].message).eql('Async functions should always return a Promise!')
+      expect(collection[0].message).eql('Async functions should always return a Promise. Instead returned void')
       expect(result[0].TSDef).eql([
         "public baz(first: string, ...others: string[]): void"
       ])

--- a/test/noted-objects-analysis/members-parser.js
+++ b/test/noted-objects-analysis/members-parser.js
@@ -203,6 +203,32 @@ describe('members-parser.js', () => {
       ])
     });
 
+    it('accept async functions that return a typed Promise', () => {
+      const source = [
+        {
+          startCommentPos: 1,
+          endCommentPos: 359,
+          comment:
+`/**
+* Variadic function
+* @param {string} first First string to concatenate
+* @param {...string} others others to concatenate
+* @return {Promise<string>}
+* @memberof Foo.Bar`,
+          value:  'Foo.Bar',
+          definition: 'async baz(first, ...others){',
+          modifiers: ['public'],
+          type: 'method'
+        }
+      ]
+
+      const result = createMembersTSDefs(source);
+
+      expect(result[0].TSDef).eql([
+        "public baz(first: string, ...others: string[]): Promise<string>"
+      ])
+    });
+
     it('process class extension with methods using functions in object property', ()=> {
       const source = [
         {


### PR DESCRIPTION
## Description

Last PR was not producing valid definition files. This fixes TS 1040 error about async in ambient contexts

## Proposed Changes

  - Removes async modifier