### PR TITLE
48942 Allow multi-line property descriptions and special characters [{...}] in typedefinitions

### DIFF
--- a/src/noted-objects-analysis/types-parser.js
+++ b/src/noted-objects-analysis/types-parser.js
@@ -128,7 +128,7 @@ function getProperties(comment) {
       .substring(pos, nextPropertyIndex < 0 ? comment.length - 1 : nextPropertyIndex)
       .replace(/\n\s*\*\s*/g, "\n * ") // reduce whitespace around *
       .replace(/\s\*\s$/, ""); // remove last empty line
-    const deconstruction = /\{(.*?:)?(.*?)\}\s+(\[[A-z0-9\_=\'\"\s]+\]|[A-z0-9\_=\'\"]+)\s*([\s\S]*)/g.exec(propertyStr);
+    const deconstruction = /\{(.*?:)?(.*?)\}\s+(\[[\w\_=\'\"\s]+\]|[\w\_=\'\"]+)\s*([\s\S]*)/g.exec(propertyStr);
 
     if (deconstruction && deconstruction.length === 5) {
       const type = fixType(deconstruction[2].trim());

--- a/src/noted-objects-analysis/types-parser.js
+++ b/src/noted-objects-analysis/types-parser.js
@@ -123,8 +123,12 @@ function getProperties(comment) {
 
   let pos = -1
   while ((pos = comment.indexOf('@property', pos + 1)) > -1) {
-    const propertyStr = comment.substring(pos, comment.indexOf('\n', pos));
-    const deconstruction = /\{(.*?:)?(.*?)\}\s*(\[[A-z0-9\_=\'\"\s]+\]|[A-z0-9\_=\'\"]+)\s*(.*)/g.exec(propertyStr);
+    const nextPropertyIndex = comment.indexOf('@property', pos + 1);
+    const propertyStr = comment
+      .substring(pos, nextPropertyIndex < 0 ? comment.length - 1 : nextPropertyIndex)
+      .replace(/\n\s*\*\s*/g, "\n * ") // reduce whitespace around *
+      .replace(/\s\*\s$/, ""); // remove last empty line
+    const deconstruction = /\{(.*?:)?(.*?)\}\s+(\[[A-z0-9\_=\'\"\s]+\]|[A-z0-9\_=\'\"]+)\s*([\s\S]*)/g.exec(propertyStr);
 
     if (deconstruction && deconstruction.length === 5) {
       const type = fixType(deconstruction[2].trim());

--- a/test/code-analysis/comment-collector.js
+++ b/test/code-analysis/comment-collector.js
@@ -159,7 +159,6 @@ Foo.Bar.method = (arg1, arg2) => {};
 `;
 
       const result = collectAllNotedObjects(source);
-      console.log(result)
 
       expect(result.names.length).eql(0);
       expect(result.types.length).eql(0);
@@ -181,7 +180,6 @@ Foo.Bar.method = (arg1, arg2) => {};
 instanceMethod(arg1, arg2) {};
 `;
       const result = collectAllNotedObjects(source);
-      console.log(result.members[0]);
 
       expect(result.names.length).eql(0);
       expect(result.types.length).eql(0);
@@ -203,7 +201,6 @@ instanceMethod(arg1, arg2) {};
 static aFunction(arg1, arg2) {};
 `;
       const result = collectAllNotedObjects(source);
-      console.log(result.members[0]);
 
       expect(result.names.length).eql(0);
       expect(result.types.length).eql(0);
@@ -225,7 +222,6 @@ static aFunction(arg1, arg2) {};
 async aFunction(arg1, arg2) {};
 `;
       const result = collectAllNotedObjects(source);
-      console.log(result.members[0]);
 
       expect(result.names.length).eql(0);
       expect(result.types.length).eql(0);

--- a/test/noted-objects-analysis/types-parser.js
+++ b/test/noted-objects-analysis/types-parser.js
@@ -73,7 +73,7 @@ describe('types-parser.js', () => {
         comment: `
 /**
  * @typedef Namespace~SomeType
- * @property {string} param1 description
+ * @property {string} [param1] description
  *    and on next line [[10.05, 15, {...}],[10.06, 10, {...}],...]
  */`,
         value: 'Namespace~SomeType',
@@ -87,7 +87,7 @@ describe('types-parser.js', () => {
       expect(result[0].fields.length).eql(1);
       expect(result[0].fields[0].type).eql('string');
       expect(result[0].fields[0].name).eql('param1');
-      expect(result[0].fields[0].description).eql('description \n * and on next line [[10.05, 15, {...}],[10.06, 10, {...}],...]');
+      expect(result[0].fields[0].description).eql('description\n * and on next line [[10.05, 15, {...}],[10.06, 10, {...}],...]');
       expect(result[0].fields[0].value).eql(null);
       expect(result[0].fields[0].opt).eql(true);
     });

--- a/test/noted-objects-analysis/types-parser.js
+++ b/test/noted-objects-analysis/types-parser.js
@@ -66,6 +66,31 @@ describe('types-parser.js', () => {
       expect(result[0].fields[0].value).eql(null);
       expect(result[0].fields[0].opt).eql(true);
     });
+    it('handle multiline descriptions and { in description field', () => {
+      const source = [{
+        startCommentPos: 1,
+        endCommentPos: 111,
+        comment: `
+/**
+ * @typedef Namespace~SomeType
+ * @property {string} param1 description
+ *    and on next line [[10.05, 15, {...}],[10.06, 10, {...}],...]
+ */`,
+        value: 'Namespace~SomeType',
+        definition: '',
+        modifiers: [],
+        type: 'typedef'
+      }];
+
+      const result = createTypedefsTSDefs(source);
+
+      expect(result[0].fields.length).eql(1);
+      expect(result[0].fields[0].type).eql('string');
+      expect(result[0].fields[0].name).eql('param1');
+      expect(result[0].fields[0].description).eql('description \n * and on next line [[10.05, 15, {...}],[10.06, 10, {...}],...]');
+      expect(result[0].fields[0].value).eql(null);
+      expect(result[0].fields[0].opt).eql(true);
+    });
     it('set properties defaults correctly', () => {
       const source = [{
         startCommentPos: 1,


### PR DESCRIPTION
Part of https://cosaic.kanbanize.com/ctrl_board/15/cards/48942
