### PR TITLE
53606 [Bug]: Framework Apps: There are several Typescript errors generated while compiling

### DIFF
--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -247,7 +247,7 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
 
     tail = `(${outputParams(params)})`;
 
-    if (constructor === false && name !== 'constructor') {
+    if (constructor === false && name !== 'constructor' && name[0] !== 'constructor') {
       tail += `: ${returns}`;
     }
   } else


### PR DESCRIPTION
Do not assign void return type to class constructors.

Task-URL: https://devservices.chartiq.com/kanbanize/53606
