### PR TITLE
53425 async keyword

### DIFF
--- a/examples/function.js
+++ b/examples/function.js
@@ -44,13 +44,12 @@ var Func4 = function(input) { return "hello!, " + input; }
 function $_Func5(input) { return "hello!, " + input; }
 
 /**
- * A simple function 6
- * @function Func6
- * @param {string} input input
- * @return {Promise<string>} output
- * @async
+ * A simple function 6 (test if async keyword gets flagged in a non-async function)
+ * @function $_Func6async
+ * @param {string} inputasync input
+ * @return {string} output
  */
-async function Func6(input) { return Promise("hello!, " + input); }
+function $_Func6async(inputasync) { return "hello!, " + inputasync; }
 
 /**
  * A simple function 7
@@ -59,5 +58,14 @@ async function Func6(input) { return Promise("hello!, " + input); }
  * @return {Promise<string>} output
  * @async
  */
-var Func7 = async function(input) { return Promise("hello!, " + input); }
+async function Func7(input) { return Promise("hello!, " + input); }
+
+/**
+ * A simple function 8
+ * @function Func8
+ * @param {string} input input
+ * @return {Promise<string>} output
+ * @async
+ */
+var Func8 = async function(input) { return Promise("hello!, " + input); }
 

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -234,8 +234,11 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     if(!name.length && !types.length) {
       name = namedFunction.exec(firstLine);
     }
+    
+    const asyncRegex = /(?<![^\s(])async(?![^\s)])/; // check for async keyword by itself or within parentheses
 
-    if (definition.includes("async") && !returns.includes("Promise")) {
+    if (asyncRegex.test(definition) && !returns.includes("Promise")) {
+		console.log(definition)
       if (returns === "void") {
 		  returns = "Promise<void>";
 	  } else {

--- a/src/noted-objects-analysis/members-parser.js
+++ b/src/noted-objects-analysis/members-parser.js
@@ -238,7 +238,6 @@ function setMemberDefinitions(definition, comment, modifiers, constructor = fals
     const asyncRegex = /(?<![^\s(])async(?![^\s)])/; // check for async keyword by itself or within parentheses
 
     if (asyncRegex.test(definition) && !returns.includes("Promise")) {
-		console.log(definition)
       if (returns === "void") {
 		  returns = "Promise<void>";
 	  } else {


### PR DESCRIPTION
## Description

Having 'async' part of a non-async function name and/or parameters is causing a warning message to show. 

Fixes # (Issue number if applicable)
[53425](https://chartiq.kanbanize.com/ctrl_board/15/cards/53425/details/)


## Proposed Changes
  - Modify how the async keyword is detected with a regex. 