### PR TITLE
Fix the "ription" = @desc being cut out of @description in typedef comments

### DIFF
--- a/src/common/common.js
+++ b/src/common/common.js
@@ -158,6 +158,13 @@ function cleanCommentData(comment, skipAdditional = []) {
         .forEach(chunk => result.push(chunk))
       break;
 
+    case str.includes('* @description'):
+      str.replace(' @description', '')
+        .split(n)
+        .map(m => ` ${m.trim()}`)
+        .forEach(chunk => result.push(chunk))
+      break;
+
     case str.includes('* @desc'):
       str.replace(' @desc', '')
         .split(n)

--- a/test/common/common.js
+++ b/test/common/common.js
@@ -125,13 +125,15 @@ describe('common.js', () => {
       expect(result).eql(target);
     });
 
-    it('remove @desc tag', () => {
+    it('remove @desc/@description tag', () => {
       const source =
 `/**
  * @desc has line
+ * @description has line
  */`;
       const target =
 `/**
+ * has line
  * has line
  */`;
 


### PR DESCRIPTION
## Description

A jsdoc block with @description tag was not understood.  Instead, the @desc was stripped off leaving only "ription".

